### PR TITLE
Update yaml, temporarily hardcode flags

### DIFF
--- a/docs/samples/transformers/feast/feast.yaml
+++ b/docs/samples/transformers/feast/feast.yaml
@@ -5,18 +5,17 @@ metadata:
 spec:
   default:
     predictor:
-      tensorflow:
-        storageUri: gs://kfserving-samples/models/tensorflow/flowers
+      sklearn:
+        storageUri: gs://kfserving-samples/models/sklearn/uber-lyft-surge
     transformer: 
       feast:
-        dataType: "ndary"
         feastUrl: "http://feast-serving.default.svc"
         entityIds:
-          - s2id 
-          - service_type
+          - source
         featureIds:
-          - sauron-s2id:1.minute_surge_sg_go_car 
-          - sauron-s2id:1.agg_minute_demand_sg_go_car 
-          - sauron-s2id:1.agg_minute_supply_sg_car 
-          - sauron-s2id:1.agg_minute_bid_accepted_sg_go_car 
-          - sauron-s2id:1.agg_minute_bid_created_sg_go_car
+          - weather:1:temp
+          - weather:1:clouds
+          - weather:1:pressure
+          - weather:1:humidity
+        omitEntities: true
+        flattenFeatures: true

--- a/python/feasttransformer/feasttransformer/transformer.py
+++ b/python/feasttransformer/feasttransformer/transformer.py
@@ -36,6 +36,8 @@ class FeastTransformer(Transformer):
                          protocol=Protocol.tensorflow_http)
         self.feast_url = feast_url
         # self.data_type = data_type
+        flatten_features = True # temporary
+        omit_entities = True # temporary
         self.entity_ids = entity_ids
         self.ids = omit_entities * entity_ids + feature_ids
         self.feature_sets = self.build_feature_sets(feature_ids)


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporarily hardcode behavior of the transformer, to avoid having to rebuild and redeploy the kfserving controller
